### PR TITLE
Ensure previous error messages are cleared

### DIFF
--- a/script.js
+++ b/script.js
@@ -63,7 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Función para mostrar errores
     function showErrors(errors) {
         // Eliminar mensajes de error anteriores
-        const existingErrors = document.querySelectorAll('.error-message');
+        const existingErrors = entryForm.querySelectorAll('.error-message, .error-container');
         existingErrors.forEach(error => error.remove());
 
         // Crear y mostrar nuevos mensajes de error
@@ -112,7 +112,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const dateInput = entryForm.querySelector('input[name="date"]');
         dateInput.valueAsDate = new Date();
         // Limpiar errores anteriores
-        const existingErrors = document.querySelectorAll('.error-message, .error-container');
+        const existingErrors = entryForm.querySelectorAll('.error-message, .error-container');
         existingErrors.forEach(error => error.remove());
     }
 
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
         modal.classList.add('hidden');
         entryForm.reset();
         // Limpiar errores
-        const existingErrors = document.querySelectorAll('.error-message, .error-container');
+        const existingErrors = entryForm.querySelectorAll('.error-message, .error-container');
         existingErrors.forEach(error => error.remove());
     }
 
@@ -232,4 +232,4 @@ document.addEventListener('DOMContentLoaded', () => {
     // Escuchar cambios en el modo oscuro
     darkModeMediaQuery.addListener(handleDarkModeChange);
     handleDarkModeChange(darkModeMediaQuery);
-}); 
+});


### PR DESCRIPTION
## Summary
- Remove existing error containers within the entry form before showing new errors or toggling the modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896c88256b48325bb696348dc404f9e