### PR TITLE
fix: replace unavailable video with playlist

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,8 @@
                 <div class="w-full md:w-2/3 lg:w-1/2">
                     <iframe class="w-full rounded-lg shadow-lg"
                         style="aspect-ratio:16/9;"
-                        src="https://www.youtube.com/embed/5noIKN8t69U?list=PLNkZbpuUYSgwTnwOi5sCjm0upSsfLWgoj&amp;index=28"
-                        title="Video recomendado de YouTube"
+                        src="https://www.youtube.com/embed/videoseries?list=PLNkZbpuUYSgwTnwOi5sCjm0upSsfLWgoj"
+                        title="Playlist de videos recomendados de YouTube"
                         frameborder="0"
                         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                         allowfullscreen></iframe>


### PR DESCRIPTION
## Summary
- replace single unavailable YouTube video with playlist embed in recommended videos section

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896cc5fc9a88325a0c6d65d6cc83b55