### PR TITLE
Add fallback YouTube video link

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,10 @@
                         frameborder="0"
                         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                         allowfullscreen></iframe>
+                    <div class="mt-6 text-center">
+                        <p class="text-lg mb-2">Charla sobre IA y futuro de Colombia</p>
+                        <a href="https://www.youtube.com/watch?v=ShYKkPPhOoc&t=1690s" target="_blank" class="text-indigo-600 hover:underline">Ver en YouTube</a>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add direct link and description to new YouTube video in recommended videos section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689818f0cb3083258b2c5b17cda283ce